### PR TITLE
Feat/authentication layout

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,7 @@
     "react/jsx-filename-extension": ["warn", { "extensions": [".ts", ".tsx"] }],
     "@typescript-eslint/camelcase": "off",
     "import/extensions": "off",
-    "no-console": "error",
+    "no-console": "warn",
     "@typescript-eslint/lines-between-class-members": "off",
     "@typescript-eslint/no-throw-literal": "off",
     "@typescript-eslint/no-use-before-define": "off",

--- a/app/components/Authentication.tsx
+++ b/app/components/Authentication.tsx
@@ -1,10 +1,14 @@
 "use client";
 
+import { MouseEvent } from "react";
+import { Card } from "@/components/ui/card";
 import { usePopupState, useToggle } from "../context/Popup";
+import Login from "./Login";
 
 export default function Authentication() {
   const isOpen = usePopupState();
   const toggle = useToggle();
+  const preventPropagation = (e: MouseEvent) => e.stopPropagation();
 
   if (isOpen) {
     return (
@@ -12,9 +16,13 @@ export default function Authentication() {
         className="w-full absolute top-0 right-0 bottom-0 bg-slate-900/75 z-50"
         onClick={toggle}
       >
-        <p className="text-white text-lg" onClick={(e) => e.stopPropagation()}>
-          배경
-        </p>
+        <Card
+          className="absolute top-40 flex flex-col max-w-[350px] mx-auto left-0 right-0"
+          onClick={preventPropagation}
+        >
+          {/* <Signup /> */}
+          <Login />
+        </Card>
       </div>
     );
   }

--- a/app/components/Authentication.tsx
+++ b/app/components/Authentication.tsx
@@ -1,14 +1,21 @@
 "use client";
 
-import { MouseEvent } from "react";
-import { Card } from "@/components/ui/card";
+import { MouseEvent, useState } from "react";
+import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { usePopupState, useToggle } from "../context/Popup";
 import Login from "./Login";
+import Signup from "./Signup";
 
 export default function Authentication() {
+  const [isMember, SetIsMember] = useState(true);
   const isOpen = usePopupState();
   const toggle = useToggle();
   const preventPropagation = (e: MouseEvent) => e.stopPropagation();
+
+  const handleClick = () => {
+    SetIsMember((p) => !p);
+  };
 
   if (isOpen) {
     return (
@@ -20,10 +27,65 @@ export default function Authentication() {
           className="absolute top-40 flex flex-col max-w-[350px] mx-auto left-0 right-0"
           onClick={preventPropagation}
         >
-          {/* <Signup /> */}
-          <Login />
+          {isMember ? (
+            <Login
+              header={<AuthenticationCardHeader text="Welcome Back" />}
+              button={
+                <AuthenticationButton
+                  isMember={isMember}
+                  onClick={handleClick}
+                />
+              }
+            />
+          ) : (
+            <Signup
+              header={<AuthenticationCardHeader text="Welcome Here" />}
+              button={
+                <AuthenticationButton
+                  isMember={isMember}
+                  onClick={handleClick}
+                />
+              }
+            />
+          )}
         </Card>
       </div>
     );
   }
+}
+
+interface AuthenticationButtonProps {
+  isMember: boolean;
+  onClick: () => void;
+}
+
+function AuthenticationButton({
+  isMember,
+  onClick,
+}: AuthenticationButtonProps) {
+  return (
+    <>
+      <Button type="submit" className="mt-3">
+        {isMember ? "Welcome Back" : "Welcome Here"}
+      </Button>
+      <div className="text-center text-sm">
+        {isMember ? "Don't have an account? " : "Already Member? "}
+        <span onClick={onClick} className="underline underline-offset-4">
+          {isMember ? "Sign up" : "Log In"}
+        </span>
+      </div>
+    </>
+  );
+}
+
+interface AuthenticationCardHeaderProps {
+  text: string;
+}
+
+function AuthenticationCardHeader({ text }: AuthenticationCardHeaderProps) {
+  return (
+    <CardHeader>
+      <CardTitle className="text-center">{text}</CardTitle>
+    </CardHeader>
+  );
 }

--- a/app/components/Login.tsx
+++ b/app/components/Login.tsx
@@ -1,10 +1,14 @@
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, ReactNode, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Button } from "@/components/ui/button";
-import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CardContent } from "@/components/ui/card";
 
-export default function Login() {
+interface LogInProps {
+  header: ReactNode;
+  button: ReactNode;
+}
+
+export default function Login({ header, button }: LogInProps) {
   const [userInput, setUserInput] = useState({
     email: "",
     password: "",
@@ -18,9 +22,7 @@ export default function Login() {
 
   return (
     <>
-      <CardHeader>
-        <CardTitle className="text-center">Welcome Back</CardTitle>
-      </CardHeader>
+      {header}
       <CardContent>
         <form className="grid gap-3">
           <Label htmlFor="email">Email</Label>
@@ -43,9 +45,7 @@ export default function Login() {
             placeholder="Enter Your Password"
             className="text-sm"
           />
-          <Button type="submit" className="mt-3">
-            Login
-          </Button>
+          {button}
         </form>
       </CardContent>
     </>

--- a/app/components/Login.tsx
+++ b/app/components/Login.tsx
@@ -1,0 +1,53 @@
+import { ChangeEvent, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Login() {
+  const [userInput, setUserInput] = useState({
+    email: "",
+    password: "",
+  });
+
+  const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+
+    setUserInput((prev) => ({ ...prev, [name]: value }));
+  };
+
+  return (
+    <>
+      <CardHeader>
+        <CardTitle className="text-center">Welcome Back</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form className="grid gap-3">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            onChange={handleInput}
+            value={userInput.email}
+            type="text"
+            id="email"
+            name="email"
+            placeholder="Enter Your Email"
+            className="text-sm"
+          />
+          <Label htmlFor="password">Password</Label>
+          <Input
+            onChange={handleInput}
+            value={userInput.password}
+            type="password"
+            id="password"
+            name="password"
+            placeholder="Enter Your Password"
+            className="text-sm"
+          />
+          <Button type="submit" className="mt-3">
+            Login
+          </Button>
+        </form>
+      </CardContent>
+    </>
+  );
+}

--- a/app/components/Signup.tsx
+++ b/app/components/Signup.tsx
@@ -1,10 +1,14 @@
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, ReactNode, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Button } from "@/components/ui/button";
-import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CardContent } from "@/components/ui/card";
 
-export default function Signup() {
+interface SignupProps {
+  header: ReactNode;
+  button: ReactNode;
+}
+
+export default function Signup({ header, button }: SignupProps) {
   const [userInput, setUserInput] = useState({
     email: "",
     password: "",
@@ -19,9 +23,7 @@ export default function Signup() {
 
   return (
     <>
-      <CardHeader>
-        <CardTitle className="text-center">Thanks for Joining</CardTitle>
-      </CardHeader>
+      {header}
       <CardContent>
         <form className="grid gap-3">
           <Label htmlFor="email">Email</Label>
@@ -54,9 +56,7 @@ export default function Signup() {
             placeholder="Enter Your Password Again"
             className="text-sm"
           />
-          <Button type="submit" className="mt-3">
-            Join!
-          </Button>
+          {button}
         </form>
       </CardContent>
     </>

--- a/app/components/Signup.tsx
+++ b/app/components/Signup.tsx
@@ -1,0 +1,64 @@
+import { ChangeEvent, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Signup() {
+  const [userInput, setUserInput] = useState({
+    email: "",
+    password: "",
+    passwordCheck: "",
+  });
+
+  const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+
+    setUserInput((prev) => ({ ...prev, [name]: value }));
+  };
+
+  return (
+    <>
+      <CardHeader>
+        <CardTitle className="text-center">Thanks for Joining</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form className="grid gap-3">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            onChange={handleInput}
+            value={userInput.email}
+            type="text"
+            id="email"
+            name="email"
+            placeholder="Enter Your Email"
+            className="text-sm"
+          />
+          <Label htmlFor="password">Password</Label>
+          <Input
+            onChange={handleInput}
+            value={userInput.password}
+            type="password"
+            id="password"
+            name="password"
+            placeholder="Enter Your Password"
+            className="text-sm"
+          />
+          <Label htmlFor="passwordCheck">Password Check</Label>
+          <Input
+            onChange={handleInput}
+            value={userInput.passwordCheck}
+            type="passwordCheck"
+            id="passwordCheck"
+            name="passwordCheck"
+            placeholder="Enter Your Password Again"
+            className="text-sm"
+          />
+          <Button type="submit" className="mt-3">
+            Join!
+          </Button>
+        </form>
+      </CardContent>
+    </>
+  );
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+);
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     ]
   },
   "dependencies": {
+    "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-navigation-menu": "^1.2.3",
     "@radix-ui/react-slot": "^1.1.1",
     "class-variance-authority": "^0.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -395,6 +395,13 @@
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.0"
 
+"@radix-ui/react-label@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-2.1.1.tgz#f30bd577b26873c638006e4f65761d4c6b80566d"
+  integrity sha512-UUw5E4e/2+4kFMH7+YxORXGWggtY6sM8WIwh5RZchhLuUg2H1hc98Py+pr8HMz6rdaYrK2t296ZEjYLOCO5uUw==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.1"
+
 "@radix-ui/react-navigation-menu@^1.2.3":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.3.tgz#b76b243235acd229b4e00fa61619547d3edf7c99"


### PR DESCRIPTION
### 작업 내용

<div align="center">

<img width="400" alt="스크린샷 2025-01-01 오후 5 11 16" src="https://github.com/user-attachments/assets/cdf4633b-b7a5-4b35-bbae-ed714ad65881" />
<br />
<img width="400" alt="스크린샷 2025-01-01 오후 5 11 30" src="https://github.com/user-attachments/assets/2cf05c8b-21bd-4c8c-8a12-a2637f2fdf4b" />

</div>

- 로그인 및 회원가입 기본 폼 완성

### 특징

<div align='center'>
<img src="https://github.com/user-attachments/assets/022bc937-56c2-4e76-924e-90c13ec1c4d4" alt="렌더링 발생" width=400 />
</div>

- 제어 컴포넌트를 사용할 때 생기는 문제점 대응
- 사용자가 입력할 때마다 렌더링이 발생한다.
- 문제는 필요없는 컴포넌트도 리렌더링된다.

<div align='center'>
<img src="https://github.com/user-attachments/assets/fd44bd61-5e06-4f45-a0d7-80f838f7271c" alt="렌더링 문제 해결" width=400 />
</div>

- 이 경우 스테이트를 옮기거나 새로운 컴포넌트를 만들어서 분리한다.
- 그러나 쓸데없는 컴포넌트들이 계속 생성되는 문제가 있다.
- 그래서 컴포넌트를 부모로 옮겨서 이를 다시 props로 전달한다.
- 이 경우 컴포넌트는 전달되는 시점에서 이미 jsx로 평가가 끝난 객체로 전달된다.
- 리액트에서 jsx는 불변 객체이다.
- 그리고 객체 비교 시, 얕은 비교를 통해 비교하기 때문에 props로 전달된 컴포넌트는 제어 컴포넌트의 리랜더링과 별개로 동작한다.