### PR TITLE
Fix/modal bug

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -1,10 +1,5 @@
-import PopupProvider from "../context/Popup";
 import HomeScene from "./components/HomeScene";
 
 export default function Home() {
-  return (
-    <PopupProvider>
-      <HomeScene />
-    </PopupProvider>
-  );
+  return <HomeScene />;
 }

--- a/app/components/Authentication/Authentication.tsx
+++ b/app/components/Authentication/Authentication.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MouseEvent, useState } from "react";
+import { MouseEvent, useCallback, useState } from "react";
 import { useFormStatus } from "react-dom";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -15,15 +15,22 @@ export default function Authentication() {
   const toggle = useToggle();
   const preventPropagation = (e: MouseEvent) => e.stopPropagation();
 
-  const handleClick = () => {
+  const handleClick = useCallback(() => {
     SetIsMember((p) => !p);
-  };
+  }, []);
+
+  const handleClose = useCallback(() => {
+    SetIsMember(true);
+  }, []);
 
   if (isOpen) {
     return (
       <div
         className="w-full absolute top-0 right-0 bottom-0 bg-slate-900/75 z-50"
-        onClick={toggle}
+        onClick={() => {
+          toggle();
+          handleClose();
+        }}
       >
         <Card
           className="absolute top-40 flex flex-col max-w-[350px] mx-auto left-0 right-0"
@@ -31,6 +38,7 @@ export default function Authentication() {
         >
           {isMember ? (
             <Login
+              onClose={handleClose}
               header={<AuthenticationCardHeader text="Welcome Back" />}
               button={
                 <AuthenticationButton
@@ -41,6 +49,7 @@ export default function Authentication() {
             />
           ) : (
             <Signup
+              onClose={handleClose}
               header={<AuthenticationCardHeader text="Welcome Here" />}
               button={
                 <AuthenticationButton

--- a/app/components/Authentication/Login.tsx
+++ b/app/components/Authentication/Login.tsx
@@ -6,7 +6,7 @@ import { useToggle } from "@/app/context/Popup";
 import { login } from "./actions/login";
 import { FormError, PropsWithReactNode } from "./type";
 
-export default function Login({ header, button }: PropsWithReactNode) {
+export default function Login({ header, button, onClose }: PropsWithReactNode) {
   const [userInput, handleInput] = useInput(initialData);
   const [formState, formAction] = useActionState(login, initialFormError);
   const toggle = useToggle();
@@ -14,8 +14,9 @@ export default function Login({ header, button }: PropsWithReactNode) {
   useEffect(() => {
     if (formState.state === "success") {
       toggle();
+      onClose();
     }
-  }, [formState, toggle]);
+  }, [toggle, onClose, formState.state]);
 
   return (
     <>

--- a/app/components/Authentication/Signup.tsx
+++ b/app/components/Authentication/Signup.tsx
@@ -6,7 +6,11 @@ import { useToggle } from "@/app/context/Popup";
 import { signup } from "./actions/signup";
 import { FormError, PropsWithReactNode } from "./type";
 
-export default function Signup({ header, button }: PropsWithReactNode) {
+export default function Signup({
+  header,
+  button,
+  onClose,
+}: PropsWithReactNode) {
   const [userInput, handleInput] = useInput(initialData);
   const [formState, formAction] = useActionState(signup, initialFormError);
   const toggle = useToggle();
@@ -14,8 +18,9 @@ export default function Signup({ header, button }: PropsWithReactNode) {
   useEffect(() => {
     if (formState.state === "success") {
       toggle();
+      onClose();
     }
-  }, [formState, toggle]);
+  }, [toggle, onClose, formState.state]);
 
   return (
     <>

--- a/app/components/Authentication/type/index.ts
+++ b/app/components/Authentication/type/index.ts
@@ -17,4 +17,5 @@ export type FormError =
 export interface PropsWithReactNode {
   header: ReactNode;
   button: ReactNode;
+  onClose: () => void;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import PopupProvider from "./context/Popup";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <PopupProvider>{children}</PopupProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
### 작업 내용

#### 버그 발생

<div align="center">
<img src="https://github.com/user-attachments/assets/fefa9389-abc8-4b70-a4ad-7c34a77417e4" width=400 />
</div>

#### 버그 수정

<div align="center">
<img src="https://github.com/user-attachments/assets/8c3b4436-5601-4f6b-b72b-fe2786186ebb" width=400 />
</div>

### 원인

- 창을 닫아도 isMember state가 유지됨
- 이 경우 컴포넌트 자체를 아예 unMount 시켜서 state를 초기화 시켜야 함.
- 그러나 state하나를 사용하기 위해서 상위 컴포넌트를 RCC로 전환 후 state를 관리하는 것을 next.js의 철학에 위배된다고 판단
- 그러므로 state 초기화 함수를 만들어 각 이벤트 헨들러에 추가
- 이 작업과 동시에 props로 전달되는 handler 함수 모두 memoization 진행(일급 객체이므로)

