### PR TITLE
Feat/gatherings

### DIFF
--- a/app/(home)/components/Gathering.tsx
+++ b/app/(home)/components/Gathering.tsx
@@ -52,7 +52,7 @@ export default function Gathering({
         <CardDescription>{newDate}</CardDescription>
       </CardHeader>
       <CardContent className="align-middle -mb-2">
-        <div id={id} className="size-44 mx-auto bg-slate-600 rounded-md" />
+        <div id={id} className="size-44 mx-auto rounded-md" />
         <p className="mt-4 mb-1">{location}</p>
       </CardContent>
     </Card>

--- a/app/(home)/components/Gathering.tsx
+++ b/app/(home)/components/Gathering.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Card,
   CardContent,
@@ -5,19 +7,21 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { useEffect } from "react";
+import { generateMap, generateMarker, generateKakaoScript } from "../util";
 
 interface GatheringProps {
   title: string;
   date: Date;
   location: string;
-  image?: string;
+  id: string;
 }
 
 export default function Gathering({
   title,
   date,
   location,
-  image,
+  id,
 }: GatheringProps) {
   const newDate = new Intl.DateTimeFormat("ko-KR", {
     year: "numeric",
@@ -27,15 +31,29 @@ export default function Gathering({
     minute: "numeric",
   }).format(date);
 
+  useEffect(() => {
+    const kakaoMapScript = generateKakaoScript();
+
+    const onLoadKakaoAPI = () => {
+      window.kakao.maps.load(() => {
+        const map = generateMap(id);
+        const marker = generateMarker();
+
+        marker.setMap(map);
+      });
+    };
+
+    kakaoMapScript.addEventListener("load", onLoadKakaoAPI);
+  }, [id]);
   return (
-    <Card className="hover:-translate-y-2 transition-all mx-auto p-1">
+    <Card className="hover:-translate-y-2 transition-all mx-auto p-1 pb-0">
       <CardHeader className="pb-2 mb-3">
         <CardTitle>{title}</CardTitle>
         <CardDescription>{newDate}</CardDescription>
       </CardHeader>
-      <CardContent className="align-middle">
-        {image || <div className="size-44 mx-auto bg-slate-600 rounded-md" />}
-        <p className="mt-3">{location}</p>
+      <CardContent className="align-middle -mb-2">
+        <div id={id} className="size-44 mx-auto bg-slate-600 rounded-md" />
+        <p className="mt-4 mb-1">{location}</p>
       </CardContent>
     </Card>
   );

--- a/app/(home)/components/Gathering.tsx
+++ b/app/(home)/components/Gathering.tsx
@@ -28,14 +28,14 @@ export default function Gathering({
   }).format(date);
 
   return (
-    <Card className="hover:-translate-y-2 transition-all">
-      <CardHeader className="mb-0 pb-2">
+    <Card className="hover:-translate-y-2 transition-all mx-auto p-1">
+      <CardHeader className="pb-2 mb-3">
         <CardTitle>{title}</CardTitle>
         <CardDescription>{newDate}</CardDescription>
       </CardHeader>
       <CardContent className="align-middle">
-        {image || <div className="size-32 mx-auto bg-slate-600 rounded-md" />}
-        <p className="mt-2">{location}</p>
+        {image || <div className="size-44 mx-auto bg-slate-600 rounded-md" />}
+        <p className="mt-3">{location}</p>
       </CardContent>
     </Card>
   );

--- a/app/(home)/components/Header.tsx
+++ b/app/(home)/components/Header.tsx
@@ -13,7 +13,7 @@ export default async function Header() {
   const isLogin = session !== undefined;
 
   return (
-    <header className="flex w-full border justify-between items-center px-2">
+    <header className="bg-white z-50 fixed top-0 left-0 right-0 flex w-full border justify-between items-center px-2">
       <NavigationMenu>
         <NavigationMenuList className="py-1 gap-2">
           <NavigationMenuItem>

--- a/app/(home)/components/HomeScene.tsx
+++ b/app/(home)/components/HomeScene.tsx
@@ -1,9 +1,15 @@
-import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
 import Gathering from "./Gathering";
 
 export default async function HomeScene() {
   return (
-    <main className="w-full">
+    <main className="w-full mt-20">
       <div className="px-auto grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-y-8 py-2 px-12 md:px-3 max-w-[1100px] mx-auto">
         <Gathering
           title="양재 클라이밍"
@@ -42,9 +48,16 @@ export default async function HomeScene() {
           id="map6"
         />
       </div>
-      <Button className="text-2xl font-thin z-50 absolute bottom-1 right-10 rounded-full px-3">
-        +
-      </Button>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger className="bg-black text-white text-2xl font-thin z-50 fixed bottom-10 right-6 rounded-full px-3 py-1">
+            +
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>모임 생성하기</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     </main>
   );
 }

--- a/app/(home)/components/HomeScene.tsx
+++ b/app/(home)/components/HomeScene.tsx
@@ -1,40 +1,50 @@
+import { Button } from "@/components/ui/button";
 import Gathering from "./Gathering";
 
 export default async function HomeScene() {
   return (
     <main className="w-full">
-      <div className="border px-auto grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-3 py-2 px-12 md:px-3">
+      <div className="px-auto grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-y-8 py-2 px-12 md:px-3 max-w-[1100px] mx-auto">
         <Gathering
           title="양재 클라이밍"
           date={new Date("2024-11-30 03:00")}
           location="더 클라이밍 양재"
+          id="map"
         />
         <Gathering
           title="양재 클라이밍"
           date={new Date("2024-12-07 03:00")}
           location="더 클라이밍 양재"
+          id="map2"
         />
         <Gathering
           title="양재 클라이밍"
           date={new Date("2024-12-14 03:00")}
           location="더 클라이밍 양재"
+          id="map3"
         />
         <Gathering
           title="양재 클라이밍"
           date={new Date("2024-12-21 03:00")}
           location="더 클라이밍 양재"
+          id="map4"
         />
         <Gathering
           title="양재 클라이밍"
           date={new Date("2024-12-28 03:00")}
           location="더 클라이밍 양재"
+          id="map5"
         />
         <Gathering
           title="양재 클라이밍"
           date={new Date("2024-01-04 03:00")}
           location="더 클라이밍 양재"
+          id="map6"
         />
       </div>
+      <Button className="text-2xl font-thin z-50 absolute bottom-1 right-10 rounded-full px-3">
+        +
+      </Button>
     </main>
   );
 }

--- a/app/(home)/util/index.ts
+++ b/app/(home)/util/index.ts
@@ -1,0 +1,30 @@
+export const generateKakaoScript = () => {
+  const kakaoMapScript = document.createElement("script");
+  kakaoMapScript.async = false;
+  kakaoMapScript.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_KEY}&autoload=false`;
+  document.head.appendChild(kakaoMapScript);
+
+  return kakaoMapScript;
+};
+
+export const generateMap = (id: string, level: number = 5) => {
+  const container = document.getElementById(id);
+  const options = {
+    center: new window.kakao.maps.LatLng(33.450701, 126.570667),
+    level,
+  };
+
+  const map = new window.kakao.maps.Map(container, options);
+
+  return map;
+};
+
+export const generateMarker = () => {
+  const markerPosition = new kakao.maps.LatLng(33.450701, 126.570667);
+
+  const marker = new kakao.maps.Marker({
+    position: markerPosition,
+  });
+
+  return marker;
+};

--- a/app/components/Authentication/Authentication.tsx
+++ b/app/components/Authentication/Authentication.tsx
@@ -26,7 +26,7 @@ export default function Authentication() {
   if (isOpen) {
     return (
       <div
-        className="w-full absolute top-0 right-0 bottom-0 bg-slate-900/75 z-50"
+        className="w-full fixed top-0 right-0 bottom-0 bg-slate-900/75 z-50"
         onClick={() => {
           toggle();
           handleClose();

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+import { cn } from "@/lib/utils";
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/global.d.ts
+++ b/global.d.ts
@@ -3,5 +3,6 @@ import type { MongoClient } from "mongodb";
 declare global {
   namespace globalThis {
     var _mongo: Promise<MongoClient>;
+    var kakao: any;
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-navigation-menu": "^1.2.3",
     "@radix-ui/react-slot": "^1.1.1",
+    "@radix-ui/react-tooltip": "^1.1.6",
     "@types/bcryptjs": "^2.4.6",
     "bcryptjs": "^2.4.3",
     "class-variance-authority": "^0.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,33 @@
   dependencies:
     levn "^0.4.1"
 
+"@floating-ui/core@^1.6.0":
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.9.tgz#64d1da251433019dafa091de9b2886ff35ec14e6"
+  integrity sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==
+  dependencies:
+    "@floating-ui/utils" "^0.2.9"
+
+"@floating-ui/dom@^1.0.0":
+  version "1.6.13"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.13.tgz#a8a938532aea27a95121ec16e667a7cbe8c59e34"
+  integrity sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==
+  dependencies:
+    "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.9"
+
+"@floating-ui/react-dom@^2.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.2.tgz#a1349bbf6a0e5cb5ded55d023766f20a4d439a31"
+  integrity sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+
+"@floating-ui/utils@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.9.tgz#50dea3616bc8191fb8e112283b49eaff03e78429"
+  integrity sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==
+
 "@humanfs/core@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.1.tgz#17c55ca7d426733fe3c561906b8173c336b40a77"
@@ -359,6 +386,13 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.1.tgz#fc169732d755c7fbad33ba8d0cd7fd10c90dc8e3"
   integrity sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==
 
+"@radix-ui/react-arrow@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.1.1.tgz#2103721933a8bfc6e53bbfbdc1aaad5fc8ba0dd7"
+  integrity sha512-NaVpZfmv8SKeZbn4ijN2V3jlHA9ngBG16VnIIm22nUR0Yk8KUALyBxT3KYEUnNuch9sTE8UTsS3whzBgKOL30w==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.1"
+
 "@radix-ui/react-collection@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.1.1.tgz#be2c7e01d3508e6d4b6d838f492e7d182f17d3b0"
@@ -429,6 +463,30 @@
     "@radix-ui/react-use-previous" "1.1.0"
     "@radix-ui/react-visually-hidden" "1.1.1"
 
+"@radix-ui/react-popper@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.2.1.tgz#2fc66cfc34f95f00d858924e3bee54beae2dff0a"
+  integrity sha512-3kn5Me69L+jv82EKRuQCXdYyf1DqHwD2U/sxoNgBGCB7K9TRc3bQamQ+5EPM9EvyPdli0W41sROd+ZU1dTCztw==
+  dependencies:
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.1.1"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.1"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+    "@radix-ui/react-use-rect" "1.1.0"
+    "@radix-ui/react-use-size" "1.1.0"
+    "@radix-ui/rect" "1.1.0"
+
+"@radix-ui/react-portal@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.3.tgz#b0ea5141103a1671b715481b13440763d2ac4440"
+  integrity sha512-NciRqhXnGojhT93RPyDaMPfLH3ZSl4jjIFbZQ1b/vxvZEdHsBZ49wP9w8L3HzUQwep01LcWtkUvm0OVB5JAHTw==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.1"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
 "@radix-ui/react-presence@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.2.tgz#bb764ed8a9118b7ec4512da5ece306ded8703cdc"
@@ -450,6 +508,24 @@
   integrity sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.1"
+
+"@radix-ui/react-tooltip@^1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.1.6.tgz#eab98e9a5c876ef0abfae3cfeee229870528ed06"
+  integrity sha512-TLB5D8QLExS1uDn7+wH/bjEmRurNMTzNrtq7IjaS4kjion9NtzsTGkvR5+i7yc9q01Pi2KMM2cN3f8UG4IvvXA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-dismissable-layer" "1.1.3"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-popper" "1.2.1"
+    "@radix-ui/react-portal" "1.1.3"
+    "@radix-ui/react-presence" "1.1.2"
+    "@radix-ui/react-primitive" "2.0.1"
+    "@radix-ui/react-slot" "1.1.1"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+    "@radix-ui/react-visually-hidden" "1.1.1"
 
 "@radix-ui/react-use-callback-ref@1.1.0":
   version "1.1.0"
@@ -480,12 +556,31 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz#d4dd37b05520f1d996a384eb469320c2ada8377c"
   integrity sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==
 
+"@radix-ui/react-use-rect@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz#13b25b913bd3e3987cc9b073a1a164bb1cf47b88"
+  integrity sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==
+  dependencies:
+    "@radix-ui/rect" "1.1.0"
+
+"@radix-ui/react-use-size@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz#b4dba7fbd3882ee09e8d2a44a3eed3a7e555246b"
+  integrity sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
 "@radix-ui/react-visually-hidden@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.1.tgz#f7b48c1af50dfdc366e92726aee6d591996c5752"
   integrity sha512-vVfA2IZ9q/J+gEamvj761Oq1FpWgCDaNOOIfbPVp2MVPLEomUr5+Vf7kJGwQ24YxZSlQVar7Bes8kyTo5Dshpg==
   dependencies:
     "@radix-ui/react-primitive" "2.0.1"
+
+"@radix-ui/rect@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.0.tgz#f817d1d3265ac5415dadc67edab30ae196696438"
+  integrity sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
### 작업 내용

<div align="center">
<Img src="https://github.com/user-attachments/assets/1defd947-66e0-4f1e-ab1b-1408f3b9fcd6" alt="지도" width=450 />
</div>

- 모임 기본 레이아웃 구현

- 이전부터 해보고 싶었던 지도 라이브러리 없이 불러오기 시도
- 결과적으로 가능하나, 사용성은 굉장히 떨어짐

### 특징

<div align="center">
<img width="600" alt="스크린샷 2025-01-08 오후 7 15 24" src="https://github.com/user-attachments/assets/075575f8-1dc5-4f31-8016-cd3fff218f6d" />
</div>
<br />

API를 로딩하는 스크립트 태그는 HTML파일안의 head, body 등 어떠한 위치에 넣어도 상관없습니다.
하지만, 반드시 실행 코드보다 먼저 선언되어야 합니다

위 글을 사용하기 위해 Next.js에서 제공하는 Script태그 사용

그러나 실행코드보다 불러오는 것 항상 실패

그래서 useEffect에서 addEventListener를 통해 해당 스크립트 'Load'된 이후 지도를 불러오도록 수정

사용성은 떨어지나 버그 방지 및 함수형 프로그래밍 연습 가능

뭐 괜찮다 생각함
