### PR TITLE
Fix/crossOrigin

### DIFF
--- a/app/(home)/types/type.ts
+++ b/app/(home)/types/type.ts
@@ -13,3 +13,7 @@ export interface IGathering {
 export interface Gathering extends Omit<IGathering, "_id"> {
   _id: ObjectId;
 }
+
+export interface KakaoMap extends HTMLScriptElement {
+  crossorigin?: string;
+}

--- a/app/(home)/util/index.ts
+++ b/app/(home)/util/index.ts
@@ -1,7 +1,10 @@
+import { KakaoMap } from "../types/type";
+
 export const generateKakaoScript = () => {
-  const kakaoMapScript = document.createElement("script");
+  const kakaoMapScript: KakaoMap = document.createElement("script");
   kakaoMapScript.async = false;
   kakaoMapScript.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_KEY}&autoload=false`;
+  kakaoMapScript.crossorigin = "anonymous";
   document.head.appendChild(kakaoMapScript);
 
   return kakaoMapScript;


### PR DESCRIPTION
### 작업 내용

kakao map에 요청 보낼 경우 CORS 위반함
- 서버에서 요청한 주소와 클라이언트에서 요청한 주소가 달라지게 됨.
- 같은 곳이라는 속성 추가

